### PR TITLE
fix(Select2Field.js) removed jquery $ references on formatted text

### DIFF
--- a/client/src/forms/Select2Field.js
+++ b/client/src/forms/Select2Field.js
@@ -19,13 +19,13 @@ $.entwine('silverware.select2', function($) {
       // Define Result Template:
       
       var templateResult = function(state) {
-        return (state.id && state.formattedResult) ? $(state.formattedResult) : state.text;
+        return (state.id && state.formattedResult) ? state.formattedResult : state.text;
       };
       
       // Define Selection Template:
       
       var templateSelection = function(state) {
-        return (state.id && state.formattedSelection) ? $(state.formattedSelection) : state.text;
+        return (state.id && state.formattedSelection) ? state.formattedSelection : state.text;
       };
       
       // Initialise Select2:


### PR DESCRIPTION
With the $ references in place, it attempts to look up elements, causing null text to be displayed to the user. Not sure what your js build process is; consider this an issue with an indicative solution to the problem :)